### PR TITLE
LMP

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -124,7 +124,7 @@ static inline int moveIsTactical(Move *move, Pos *board) {
     int to = moveTo(move);
     return board->pieceList[to] != NONE ||
            moveType(move) == ENPAS ||
-           promotePiece(move);
+           promotePiece(move) == QUEEN;
 }
 
 static inline int moveIsPseudolegal(Move *move, Pos *board) {

--- a/src/search.c
+++ b/src/search.c
@@ -228,8 +228,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
         // LMP
         if (!PVNode &&
-            !inCheck &&
-            quietcnt > 4 * depth * depth)
+            quietcnt > 2 * depth * depth)
             skipQuiets = 1;
 
         if (!makeMove(board, &move)) {

--- a/src/search.c
+++ b/src/search.c
@@ -132,6 +132,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
     int score,bestScore=-999999;
     int movecnt = 0, quietcnt = 0;
+    int allowQuiets = 1;
     Move move, bestMove;
 
     // PVS sets alpha to beta-1 on
@@ -221,7 +222,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
     int oldAlpha = alpha;
 
-    while ((move = selectNextMove(&mp, thread->hTable, board, 0)).value != NO_MOVE) {
+    while ((move = selectNextMove(&mp, thread->hTable, board, allowQuiets)).value != NO_MOVE) {
 
         isQuiet = !moveIsTactical(&move, board);
 
@@ -229,7 +230,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
         if (!PVNode &&
             !inCheck &&
             quietcnt > 4 * depth * depth)
-            break;
+            allowQuiets = 0;
 
         if (!makeMove(board, &move)) {
             undoMove(board, &move, &mp.undo);

--- a/src/search.c
+++ b/src/search.c
@@ -131,7 +131,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
     pv->length = 0;
 
     int score,bestScore=-999999;
-    int movecnt = 0;
+    int movecnt = 0, quietcnt = 0;
     Move move, bestMove;
 
     // PVS sets alpha to beta-1 on
@@ -225,12 +225,17 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
         isQuiet = !moveIsTactical(&move, board);
 
+        if (!PVNode &&
+            quietcnt > 4 * depth * depth)
+            break;
+
         if (!makeMove(board, &move)) {
             undoMove(board, &move, &mp.undo);
             continue;
         }
 
         movecnt++;
+        quietcnt += isQuiet;
 
         if (RootNode && thread->index == 0 && timeSearched(thread) > 2000) {
             reportMoveInfo(move, *board, movecnt);

--- a/src/search.c
+++ b/src/search.c
@@ -132,7 +132,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
     int score,bestScore=-999999;
     int movecnt = 0, quietcnt = 0;
-    int allowQuiets = 1;
+    int skipQuiets = 0;
     Move move, bestMove;
 
     // PVS sets alpha to beta-1 on
@@ -222,7 +222,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
     int oldAlpha = alpha;
 
-    while ((move = selectNextMove(&mp, thread->hTable, board, allowQuiets)).value != NO_MOVE) {
+    while ((move = selectNextMove(&mp, thread->hTable, board, skipQuiets)).value != NO_MOVE) {
 
         isQuiet = !moveIsTactical(&move, board);
 
@@ -230,7 +230,7 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
         if (!PVNode &&
             !inCheck &&
             quietcnt > 4 * depth * depth)
-            allowQuiets = 0;
+            skipQuiets = 1;
 
         if (!makeMove(board, &move)) {
             undoMove(board, &move, &mp.undo);

--- a/src/search.c
+++ b/src/search.c
@@ -225,7 +225,9 @@ int alphaBeta(Pos *board, int alpha, int beta, int depth, int height, Thread *th
 
         isQuiet = !moveIsTactical(&move, board);
 
+        // LMP
         if (!PVNode &&
+            !inCheck &&
             quietcnt > 4 * depth * depth)
             break;
 


### PR DESCRIPTION
Prune quiet moves after a certain amount has been searched. Assuming that move ordering is correct, then later moves are worse, and therefore not searching. Since move ordering is not perfect the amount of moves needed to be searched is adjusted based on depth.